### PR TITLE
Fix CAA failure in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,19 @@ VECTOR_DB_TYPE=pinecone
 API_HOST=0.0.0.0
 API_PORT=8000
 
+# Production SSL/Security Configuration
+# Set these for production deployment (see docs/markdowns/SSL_CAA_SETUP.md)
+PRODUCTION=false
+HTTPS_ONLY=false
+
+# Domain configuration - comma-separated list of allowed hosts
+# Example: TRUSTED_HOSTS=yourdomain.com,www.yourdomain.com
+TRUSTED_HOSTS=*
+
+# CORS Origins - comma-separated list of allowed origins
+# Example: ALLOWED_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
+ALLOWED_ORIGINS=*
+
 # Disable telemetry and warnings
 TOKENIZERS_PARALLELISM=false
 ANONYMIZED_TELEMETRY=false

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,15 @@ env/
 ENV/
 data/hackathon_data
 docs/beatbyteai_id_rsa
+
+# SSL Certificates (never commit actual certs)
+nginx/ssl/*.pem
+nginx/ssl/*.crt
+nginx/ssl/*.key
+nginx/ssl/live/
+nginx/ssl/archive/
+!nginx/ssl/.gitkeep
+
+# Certbot data
+certbot/conf/
+!certbot/www/.gitkeep

--- a/certbot/www/.gitkeep
+++ b/certbot/www/.gitkeep
@@ -1,0 +1,2 @@
+# Certbot webroot directory for ACME challenges
+# This directory is used by Let's Encrypt for domain validation

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,96 @@
+# SOCAR AI System - Production Docker Compose with SSL/TLS Support
+# This configuration includes nginx reverse proxy with SSL termination
+#
+# Prerequisites:
+# 1. Set up CAA DNS records for your domain (see docs/markdowns/SSL_CAA_SETUP.md)
+# 2. Generate SSL certificates using certbot or your CA
+# 3. Copy certificates to ./nginx/ssl/
+#
+# Usage:
+#   docker-compose -f docker-compose.prod.yml up -d
+
+version: '3.8'
+
+services:
+  # Nginx reverse proxy with SSL termination
+  nginx:
+    image: nginx:alpine
+    container_name: socar-nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/ssl:/etc/nginx/ssl:ro
+      - ./certbot/www:/var/www/certbot:ro
+    depends_on:
+      socar-ai-system:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:80/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - socar-network
+    labels:
+      - "com.socar.service=nginx-proxy"
+      - "com.socar.ssl=enabled"
+
+  # Certbot for automatic SSL certificate renewal (Let's Encrypt)
+  certbot:
+    image: certbot/certbot:latest
+    container_name: socar-certbot
+    volumes:
+      - ./nginx/ssl:/etc/letsencrypt:rw
+      - ./certbot/www:/var/www/certbot:rw
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    networks:
+      - socar-network
+    labels:
+      - "com.socar.service=certbot"
+      - "com.socar.purpose=ssl-renewal"
+
+  # Main SOCAR AI System
+  socar-ai-system:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: socar-ai-system
+    # Only expose internally to nginx (not to host)
+    expose:
+      - "8000"
+    env_file:
+      - .env
+    environment:
+      - PYTHONUNBUFFERED=1
+      - PRODUCTION=true
+      - HTTPS_ONLY=true
+      - TRUSTED_HOSTS=${TRUSTED_HOSTS:-localhost}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    networks:
+      - socar-network
+    labels:
+      - "com.socar.description=SOCAR Historical Documents AI System"
+      - "com.socar.features=OCR,LLM,Frontend"
+      - "com.socar.version=1.0.0"
+      - "com.socar.environment=production"
+
+networks:
+  socar-network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16
+
+# Volume for persistent SSL certificates
+volumes:
+  ssl-certs:
+    driver: local

--- a/docs/markdowns/SSL_CAA_SETUP.md
+++ b/docs/markdowns/SSL_CAA_SETUP.md
@@ -1,0 +1,292 @@
+# SSL/TLS and CAA DNS Record Setup Guide
+
+This guide explains how to configure SSL/TLS certificates and CAA (Certificate Authority Authorization) DNS records for the SOCAR AI System in production.
+
+## What is CAA?
+
+CAA (Certificate Authority Authorization) is a DNS record type that specifies which Certificate Authorities (CAs) are authorized to issue SSL/TLS certificates for your domain. This prevents unauthorized certificate issuance and helps protect against man-in-the-middle attacks.
+
+## Prerequisites
+
+1. A registered domain name
+2. Access to your DNS provider's management console
+3. Docker and Docker Compose installed
+4. The SOCAR AI System codebase
+
+## Step 1: Configure CAA DNS Records
+
+Add the following CAA records to your domain's DNS configuration:
+
+### For Let's Encrypt (Recommended - Free)
+
+```dns
+yourdomain.com.  CAA  0 issue "letsencrypt.org"
+yourdomain.com.  CAA  0 issuewild "letsencrypt.org"
+yourdomain.com.  CAA  0 iodef "mailto:security@yourdomain.com"
+```
+
+### For Other Certificate Authorities
+
+| CA Provider | CAA Record Value |
+|-------------|------------------|
+| Let's Encrypt | `letsencrypt.org` |
+| DigiCert | `digicert.com` |
+| Comodo/Sectigo | `sectigo.com` |
+| GlobalSign | `globalsign.com` |
+| Amazon (ACM) | `amazon.com` |
+| Cloudflare | `cloudflare.com` |
+| ZeroSSL | `zerossl.com` |
+
+### DNS Record Examples
+
+**Using Cloudflare:**
+1. Go to DNS settings
+2. Add a CAA record:
+   - Name: `@` (or your subdomain)
+   - Tag: `issue`
+   - CA domain name: `letsencrypt.org`
+
+**Using AWS Route 53:**
+```json
+{
+  "ResourceRecords": [
+    { "Value": "0 issue \"letsencrypt.org\"" }
+  ]
+}
+```
+
+### Verify CAA Records
+
+Use these commands to verify your CAA records are properly configured:
+
+```bash
+# Using dig
+dig CAA yourdomain.com
+
+# Using nslookup
+nslookup -type=CAA yourdomain.com
+
+# Using online tools
+# https://caatest.co.uk/
+# https://dnschecker.org/
+```
+
+## Step 2: Generate SSL Certificates
+
+### Option A: Let's Encrypt with Certbot (Recommended)
+
+1. **Create required directories:**
+
+```bash
+mkdir -p nginx/ssl
+mkdir -p certbot/www
+```
+
+2. **Initial certificate generation:**
+
+```bash
+# Start nginx in HTTP-only mode first
+docker run -d --name temp-nginx \
+  -v $(pwd)/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro \
+  -v $(pwd)/certbot/www:/var/www/certbot:ro \
+  -p 80:80 \
+  nginx:alpine
+
+# Generate certificate
+docker run -it --rm \
+  -v $(pwd)/nginx/ssl:/etc/letsencrypt \
+  -v $(pwd)/certbot/www:/var/www/certbot \
+  certbot/certbot certonly \
+  --webroot \
+  --webroot-path=/var/www/certbot \
+  -d yourdomain.com \
+  -d www.yourdomain.com \
+  --email your-email@example.com \
+  --agree-tos \
+  --no-eff-email
+
+# Stop temp nginx
+docker stop temp-nginx && docker rm temp-nginx
+```
+
+3. **Copy certificates to correct location:**
+
+```bash
+cp nginx/ssl/live/yourdomain.com/fullchain.pem nginx/ssl/fullchain.pem
+cp nginx/ssl/live/yourdomain.com/privkey.pem nginx/ssl/privkey.pem
+```
+
+### Option B: Self-Signed Certificates (Development/Testing Only)
+
+```bash
+mkdir -p nginx/ssl
+
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout nginx/ssl/privkey.pem \
+  -out nginx/ssl/fullchain.pem \
+  -subj "/C=AZ/ST=Baku/L=Baku/O=SOCAR/CN=localhost"
+```
+
+### Option C: Using Existing Certificates
+
+If you have certificates from another CA:
+
+```bash
+# Copy your certificate files to the ssl directory
+cp /path/to/your/fullchain.pem nginx/ssl/fullchain.pem
+cp /path/to/your/privkey.pem nginx/ssl/privkey.pem
+
+# Set correct permissions
+chmod 600 nginx/ssl/privkey.pem
+chmod 644 nginx/ssl/fullchain.pem
+```
+
+## Step 3: Configure Environment Variables
+
+Update your `.env` file with production settings:
+
+```bash
+# Production Settings
+PRODUCTION=true
+HTTPS_ONLY=true
+
+# Domain Configuration
+TRUSTED_HOSTS=yourdomain.com,www.yourdomain.com
+
+# CORS Origins (your production domains)
+ALLOWED_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
+
+# Existing configuration...
+AZURE_OPENAI_API_KEY=your_key_here
+# ... rest of your config
+```
+
+## Step 4: Deploy with Production Docker Compose
+
+```bash
+# Start the production stack
+docker-compose -f docker-compose.prod.yml up -d
+
+# Check logs
+docker-compose -f docker-compose.prod.yml logs -f
+
+# Verify health
+curl -k https://yourdomain.com/health
+```
+
+## Step 5: Verify SSL Configuration
+
+### Test SSL Certificate
+
+```bash
+# Test SSL connection
+openssl s_client -connect yourdomain.com:443 -servername yourdomain.com
+
+# Check certificate details
+echo | openssl s_client -connect yourdomain.com:443 2>/dev/null | openssl x509 -noout -text
+
+# Test with curl
+curl -I https://yourdomain.com/health
+```
+
+### Online SSL Testing Tools
+
+- [SSL Labs Server Test](https://www.ssllabs.com/ssltest/)
+- [Qualys SSL Checker](https://www.ssllabs.com/ssltest/)
+- [SSL Shopper Checker](https://www.sslshopper.com/ssl-checker.html)
+
+## Step 6: Certificate Renewal
+
+### Automatic Renewal (with Certbot container)
+
+The `docker-compose.prod.yml` includes a certbot container that automatically renews certificates every 12 hours. No manual action required.
+
+### Manual Renewal
+
+```bash
+docker-compose -f docker-compose.prod.yml exec certbot certbot renew
+
+# Reload nginx to use new certificates
+docker-compose -f docker-compose.prod.yml exec nginx nginx -s reload
+```
+
+## Troubleshooting
+
+### CAA Record Issues
+
+**Error: "CAA record prevents issuance"**
+- Verify CAA records include your CA
+- Wait for DNS propagation (up to 48 hours)
+- Use `dig CAA yourdomain.com` to verify
+
+**Error: "DNS resolution failed"**
+- Check your domain's DNS configuration
+- Verify nameservers are responding
+- Check for DNSSEC issues
+
+### SSL Certificate Issues
+
+**Error: "Certificate not yet valid"**
+- Check server time synchronization
+- Run `ntpdate pool.ntp.org`
+
+**Error: "Certificate has expired"**
+- Renew certificate: `certbot renew`
+- Check certbot logs for renewal failures
+
+**Error: "Certificate chain incomplete"**
+- Ensure fullchain.pem includes intermediate certificates
+- Verify certificate order in the chain
+
+### Nginx Issues
+
+**Error: "nginx: [emerg] cannot load certificate"**
+- Check file permissions (644 for cert, 600 for key)
+- Verify file paths in nginx.conf
+- Check file exists: `ls -la nginx/ssl/`
+
+**Error: "502 Bad Gateway"**
+- Check if backend container is running
+- Verify network connectivity between containers
+- Check backend health: `docker logs socar-ai-system`
+
+## Security Best Practices
+
+1. **Keep CAA records updated** - If you change CAs, update CAA records
+2. **Monitor certificate expiry** - Set up alerts for expiring certificates
+3. **Use HSTS preloading** - Submit domain to [HSTS Preload List](https://hstspreload.org/)
+4. **Disable old protocols** - Only allow TLS 1.2 and 1.3
+5. **Regular security audits** - Run SSL Labs tests periodically
+6. **Backup certificates** - Store copies of certificates securely
+
+## File Structure
+
+After setup, your directory should look like:
+
+```
+SOCAR_Hackathon/
+├── nginx/
+│   ├── nginx.conf
+│   └── ssl/
+│       ├── fullchain.pem
+│       └── privkey.pem
+├── certbot/
+│   └── www/
+│       └── .well-known/
+│           └── acme-challenge/
+├── docker-compose.prod.yml
+├── .env
+└── ...
+```
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Start production stack | `docker-compose -f docker-compose.prod.yml up -d` |
+| Stop production stack | `docker-compose -f docker-compose.prod.yml down` |
+| View logs | `docker-compose -f docker-compose.prod.yml logs -f` |
+| Renew certificates | `docker-compose -f docker-compose.prod.yml exec certbot certbot renew` |
+| Reload nginx | `docker-compose -f docker-compose.prod.yml exec nginx nginx -s reload` |
+| Check SSL | `openssl s_client -connect yourdomain.com:443` |
+| Check CAA | `dig CAA yourdomain.com` |

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,102 @@
+# SOCAR AI System - Production Nginx Configuration with SSL/TLS
+# This configuration provides SSL termination and reverse proxy for production
+
+upstream socar_backend {
+    server socar-ai-system:8000;
+    keepalive 32;
+}
+
+# Redirect HTTP to HTTPS
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+
+    # ACME challenge location for Let's Encrypt/certbot
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # Redirect all other traffic to HTTPS
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS server block
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name _;
+
+    # SSL Certificate Configuration
+    # For production: Use Let's Encrypt or your CA certificates
+    ssl_certificate /etc/nginx/ssl/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+
+    # SSL Configuration - Modern settings for security
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
+    # SSL Session settings
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    # OCSP Stapling
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    resolver 8.8.8.8 8.8.4.4 valid=300s;
+    resolver_timeout 5s;
+
+    # Security Headers
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:;" always;
+
+    # Logging
+    access_log /var/log/nginx/socar_access.log;
+    error_log /var/log/nginx/socar_error.log;
+
+    # Client settings
+    client_max_body_size 100M;
+    client_body_buffer_size 10M;
+
+    # Proxy settings for API
+    location / {
+        proxy_pass http://socar_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_cache_bypass $http_upgrade;
+
+        # Timeouts for long-running LLM requests
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 120s;
+        proxy_read_timeout 120s;
+    }
+
+    # Static files with caching
+    location /static/ {
+        proxy_pass http://socar_backend;
+        proxy_cache_valid 200 1d;
+        add_header Cache-Control "public, max-age=86400";
+    }
+
+    # Health check endpoint (no caching)
+    location /health {
+        proxy_pass http://socar_backend;
+        proxy_cache_bypass 1;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+}

--- a/nginx/ssl/.gitkeep
+++ b/nginx/ssl/.gitkeep
@@ -1,0 +1,8 @@
+# SSL certificates directory
+# Place your SSL certificates here:
+# - fullchain.pem: Your full certificate chain
+# - privkey.pem: Your private key
+#
+# See docs/markdowns/SSL_CAA_SETUP.md for setup instructions
+#
+# IMPORTANT: Never commit actual certificate files to git!


### PR DESCRIPTION
- Add nginx reverse proxy with SSL termination (nginx/nginx.conf)
- Create production docker-compose with certbot for auto-renewal
- Fix insecure CORS policy (wildcards -> configurable origins)
- Add security headers middleware (HSTS, CSP, X-Frame-Options, etc.)
- Add trusted host middleware to prevent host header attacks
- Create comprehensive SSL/CAA setup documentation
- Update .env.example with production security variables
- Add .gitignore entries to protect SSL certificates